### PR TITLE
IT executed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <testcontainers.version>1.18.0</testcontainers.version>
     <querydsl.version>5.0.0</querydsl.version>
     <jjwt.version>0.9.1</jjwt.version>
+    <failsafe.version>3.1.0</failsafe.version>
   </properties>
   <dependencies>
     <dependency>
@@ -192,10 +193,6 @@
         </dependencies>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
@@ -203,6 +200,22 @@
             <include>**/*Spec.*</include>
             <include>**/*Test.*</include>
           </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${failsafe.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classesDirectory>${project.build.outputDirectory}</classesDirectory>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
closes #101 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `maven-failsafe-plugin` version `3.1.0` to the `pom.xml` file, which allows for integration testing and verification of the project. 

### Detailed summary
- Added `failsafe.version` property to `pom.xml`
- Added `maven-failsafe-plugin` version `3.1.0` to `pom.xml`
- Configured `maven-failsafe-plugin` to run `integration-test` and `verify` goals
- Set `classesDirectory` to `${project.build.outputDirectory}` in `maven-failsafe-plugin` configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->